### PR TITLE
Fix reform version depencency so it works with reform 2.2

### DIFF
--- a/reform-rails.gemspec
+++ b/reform-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "reform", "~> 2.0.0"
+  spec.add_dependency "reform", "~> 2.0"
   spec.add_dependency "activemodel", ">= 3.2"
 
   spec.add_development_dependency "rails"


### PR DESCRIPTION
With '~> 2.0.0', reform 2.2 does not satisfy the dependecy, which it should, as far as I can tell.