### PR TITLE
Add support collection as Array

### DIFF
--- a/lib/reform/form/active_model/form_builder_methods.rb
+++ b/lib/reform/form/active_model/form_builder_methods.rb
@@ -40,7 +40,7 @@ module Reform::Form::ActiveModel
       return unless params.has_key?(nested_name)
 
       value = params["#{name}_attributes"]
-      value = value.values if dfn[:collection]
+      value = value.values if dfn[:collection] && value.is_a?(Hash)
 
       params[name] = value
     end


### PR DESCRIPTION
Hi there!

Sometimes when you use Rails with trailblazer as API in application it's necessary to pass collection's parameters like `members_attributes` as Array.

For me it is necessary because I use Rails API with trailblazer on backend and EmberJS on frontend. This small fix solves problem with collection's parameters as Array and still allows for them to be passed as Hash.