### PR TITLE
Change setup to happen after initializers

### DIFF
--- a/lib/reform/rails/railtie.rb
+++ b/lib/reform/rails/railtie.rb
@@ -3,7 +3,7 @@ module Reform
     class Railtie < ::Rails::Railtie
       config.reform = ActiveSupport::OrderedOptions.new
 
-      initializer "reform.form_extensions", before: :load_config_initializers do
+      initializer "reform.form_extensions", after: :load_config_initializers do
         validations = config.reform.validations || :active_model
 
         if validations == :active_model


### PR DESCRIPTION
Model/form setup should happen after load_config_initializers or changes made to config.reform.validations in initializers will not be picked up.