### PR TITLE
support nil as model for reform

### DIFF
--- a/lib/reform/active_record.rb
+++ b/lib/reform/active_record.rb
@@ -1,4 +1,5 @@
 require "reform/form/active_model"
 require "reform/form/orm"
 require "reform/form/active_record"
+require "reform/form/not_persisted"
 require "reform/form/active_model/model_reflections" # only load this in AR context as simple_form currently is bound to AR.

--- a/lib/reform/form/not_persisted.rb
+++ b/lib/reform/form/not_persisted.rb
@@ -1,0 +1,26 @@
+# Support nil models (aka reform without backed model)
+module Reform::Form::NotPersisted
+  def self.included(base)
+    base.class_eval do
+      register_feature Reform::Form::NotPersisted
+
+      def persisted?
+        false
+      end
+
+      def to_key
+        nil # see http://apidock.com/rails/ActiveModel/Conversion/to_key : nil if no key attributes
+      end
+
+      def to_param
+        nil # see http://apidock.com/rails/ActiveModel/Conversion/to_param : nil if not persisted
+      end
+
+      def id
+        nil
+      end
+
+    end
+  end
+end
+

--- a/lib/reform/rails/railtie.rb
+++ b/lib/reform/rails/railtie.rb
@@ -20,6 +20,7 @@ module Reform
         require "reform/form/active_model/model_validations"
         require "reform/form/active_model/form_builder_methods"
         require "reform/form/active_model"
+        require "reform/form/not_persisted"
         require "reform/form/active_model/validations"
         require "reform/form/multi_parameter_attributes"
 
@@ -44,6 +45,7 @@ module Reform
 
         # This adds Form#persisted? and all the other crap #form_for depends on. Grrrr.
         require "reform/form/active_model" # DISCUSS: only when using simple_form.
+        require "reform/form/not_persisted"
 
         Reform::Form.class_eval do
           include Reform::Form::ActiveModel # DISCUSS: only when using simple_form.

--- a/test/active_model_test.rb
+++ b/test/active_model_test.rb
@@ -138,6 +138,25 @@ class NewActiveModelTest < MiniTest::Spec # TODO: move to test/rails/
   end
 end
 
+class ActiveModelWithNilModel < MiniTest::Spec
+  class SongForm < Reform::Form
+    include Reform::Form::ActiveModel
+    include Reform::Form::NotPersisted
+
+    property :name, virtual: true
+  end
+
+  let (:form) { SongForm.new(nil) }
+
+  it do
+    form.persisted?.must_equal false
+    form.to_key.must_equal nil
+    form.to_param.must_equal nil
+    form.to_model.must_equal form
+    form.id.must_equal nil
+    form.model_name.must_equal form.class.model_name
+  end
+end
 
 class ActiveModelWithCompositionTest < MiniTest::Spec
    class HitForm < Reform::Form


### PR DESCRIPTION
In some cases reform is just used for coercion & validation without any persistence done.
In these cases it was advised to use nil as reform model & to mark all properties as virtual.

this works fine, however fails as .persisted? is called on nil  upon rendering in actionpack-3.2.22.2/lib/action_view/helpers/form_helper.rb:388

    ...
      as = options[:as]
        action, method = object.respond_to?(:persisted?) && object.persisted? ? [:edit, :put] : [:new, :post]
        options[:html].reverse_merge!(
          :class  => as ? "#{action}_#{as}" : dom_class(object, action),
          :id     => as ? "#{action}_#{as}" : [options[:namespace], dom_id(object, action)].compact.join("_").presence,
          :method => method
        )
     ...