### PR TITLE
Reform changes

### DIFF
--- a/lib/reform/form/active_model.rb
+++ b/lib/reform/form/active_model.rb
@@ -40,6 +40,18 @@ module Reform::Form::ActiveModel
       end
     end
 
+    # moved from reform as not applicable to dry
+    def validates(*args, &block)
+      validation(:default, inherit: true) { validates *args, &block }
+    end
+
+    def validate(*args, &block)
+      validation(:default, inherit: true) { validate *args, &block }
+    end
+
+    def validates_with(*args, &block)
+      validation(:default, inherit: true) { validates_with *args, &block }
+    end
 
     # Set a model name for this form if the infered is wrong.
     #

--- a/lib/reform/form/active_model/validations.rb
+++ b/lib/reform/form/active_model/validations.rb
@@ -44,7 +44,7 @@ module Reform::Form::ActiveModel
     end
 
     class Group
-      def initialize
+      def initialize(_options={})
         @validations = Class.new(Reform::Form::ActiveModel::Validations::Validator)
       end
 
@@ -60,7 +60,6 @@ module Reform::Form::ActiveModel
         end
       end
     end
-
 
     # Validator is the validatable object. On the class level, we define validations,
     # on instance, it exposes #valid?.


### PR DESCRIPTION
1. move more AM-V methods from Reform to Reform-rails
2. enable the passing of options to a group def for reform (needed in dry-v)