### PR TITLE
Use private_name of attribute on unique validation

### DIFF
--- a/lib/reform/form/validation/unique_validator.rb
+++ b/lib/reform/form/validation/unique_validator.rb
@@ -31,19 +31,21 @@
 class Reform::Form::UniqueValidator < ActiveModel::EachValidator
   def validate_each(form, attribute, value)
     model = form.model_for_property(attribute)
+    original_attribute = form.options_for(attribute)[:private_name]
 
-    # search for models with attribute equals to form field value
-    query = model.class.where(attribute => value)
-
+    # search for models with original attribute equals to form field value
+    query = model.class.where(original_attribute => value)
+    # if model persisted, query should bypass model
+    if model.persisted?
+      query = query.where.not(id: model.id)
+    end
     # apply scope if options has been declared
     Array(options[:scope]).each do |field|
       # add condition to only check unique value with the same scope
       query = query.where(field => form.send(field))
     end
 
-    # if model persisted, query may return 0 or 1 rows, else 0
-    allow_count = model.persisted? ? 1 : 0
-    form.errors.add(attribute, :taken) if query.count > allow_count
+    form.errors.add(attribute, :taken) if query.count > 0
   end
 end
 


### PR DESCRIPTION
If we declared property like this:
```
property :field, from: :another_field
```
now it raises error, because there is no column `:field` in database.  
