### PR TITLE
params.merge! is deprecated in Rails 5

### DIFF
--- a/lib/reform/form/multi_parameter_attributes.rb
+++ b/lib/reform/form/multi_parameter_attributes.rb
@@ -19,7 +19,11 @@ module Reform::Form::MultiParameterAttributes
           )
         end
       end
-      params.merge!(date_attributes)
+
+      date_attributes.each do |attribute, date|
+        params[attribute] = date
+      end
+      params
     end
 
   private


### PR DESCRIPTION
In Rails 5, when using the `MultiParameterAttributes` feature, Rails shows:

DEPRECATION WARNING: Method merge! is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.0.1/classes/ActionController/Parameters.html

This pull request fixes this (nothing fancy, just the obvious solution).
