### PR TITLE
to_model should return model, not the form

### DIFF
--- a/lib/reform/form/active_model.rb
+++ b/lib/reform/form/active_model.rb
@@ -10,7 +10,7 @@ module Reform::Form::ActiveModel
       delegates :model, *[:persisted?, :to_key, :to_param, :id] # Uber::Delegates
 
       def to_model # this is called somewhere in FormBuilder and ActionController.
-        self
+        self.model
       end
     end
   end


### PR DESCRIPTION
to_model will be called in FormBuilder, and it should return a model but not a form