### PR TITLE
WIP: BaseSchema for dry-v configuration

### DIFF
--- a/lib/reform/form/dry/validations.rb
+++ b/lib/reform/form/dry/validations.rb
@@ -1,0 +1,18 @@
+module Reform::Form::Dry
+  module Validations
+    class Group
+      def initialize(options = {})
+        options ||= {}
+        schema_class = options[:schema] || BaseSchema
+        @validator = Dry::Validation.Schema(schema_class, build: false)
+
+        @schema_inject_params = options[:with] || {}
+      end
+    end
+
+    class BaseSchema < Dry::Validation::Schema
+      config.messages_file = "config/locales/errors.#{I18n.locale}.yml"
+      config.messages = :i18n
+    end
+  end
+end

--- a/lib/reform/rails/railtie.rb
+++ b/lib/reform/rails/railtie.rb
@@ -48,6 +48,7 @@ module Reform
         end
 
         require "reform/form/dry"
+        require "reform/form/dry/validations"
 
         Reform::Form.class_eval do
           if enable_am

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require 'minitest/autorun'
 
 # Load the rails application
 require "active_model/railtie"
+require "bundler/setup"
 
 Bundler.require
 


### PR DESCRIPTION
@apotonick @fran-worley 

Right now, we can inject custom schemas to validation blocks like this:

```
validation schema: MySchema do
end

class MySchema < Dry::Validation::Schema
  config.message_files = "path/to/errors"
end
```

However this has to be done on each validation block. I think it's safe to assume that any Rails app would have a need for custom error messages, and is worth considering as default behaviour for reform-rails, or perhaps a configurable option in Rails. Here is a quick monkey patch for demonstration 🐒 🔧 