### PR TITLE
Do not include database.sqlite3 in a gem

### DIFF
--- a/reform-rails.gemspec
+++ b/reform-rails.gemspec
@@ -14,7 +14,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/trailblazer/reform-rails"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+                         f.match(%r{^(test/|spec/|features/|database.sqlite3)})
+                       end
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
## Before 
```console
$ ruby -e 'puts `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }'
.gitignore
.travis.yml
CHANGES.md
Gemfile
LICENSE.txt
README.md
Rakefile
database.sqlite3
lib/reform/active_record.rb
lib/reform/form/active_model.rb
lib/reform/form/active_model/form_builder_methods.rb
lib/reform/form/active_model/model_reflections.rb
lib/reform/form/active_model/model_validations.rb
lib/reform/form/active_model/validations.rb
lib/reform/form/active_record.rb
lib/reform/form/mongoid.rb
lib/reform/form/multi_parameter_attributes.rb
lib/reform/form/orm.rb
lib/reform/form/validation/unique_validator.rb
lib/reform/mongoid.rb
lib/reform/rails.rb
lib/reform/rails/railtie.rb
lib/reform/rails/version.rb
reform-rails.gemspec
```

## After
```console
$ ruby -e 'puts `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test/|spec/|features/|database.sqlite3)}) }'
.gitignore
.travis.yml
CHANGES.md
Gemfile
LICENSE.txt
README.md
Rakefile
lib/reform/active_record.rb
lib/reform/form/active_model.rb
lib/reform/form/active_model/form_builder_methods.rb
lib/reform/form/active_model/model_reflections.rb
lib/reform/form/active_model/model_validations.rb
lib/reform/form/active_model/validations.rb
lib/reform/form/active_record.rb
lib/reform/form/mongoid.rb
lib/reform/form/multi_parameter_attributes.rb
lib/reform/form/orm.rb
lib/reform/form/validation/unique_validator.rb
lib/reform/mongoid.rb
lib/reform/rails.rb
lib/reform/rails/railtie.rb
lib/reform/rails/version.rb
reform-rails.gemspec
```