### PR TITLE
Add support for StrongParameters

### DIFF
--- a/lib/reform/form/active_model/form_builder_methods.rb
+++ b/lib/reform/form/active_model/form_builder_methods.rb
@@ -3,6 +3,10 @@ module Reform::Form::ActiveModel
   # in Rails. It will further try to translate Rails' suboptimal songs_attributes weirdness
   # back to normal `songs: ` naming in +#valiate+.
   module FormBuilderMethods
+    if ActiveModel.gem_version >= Gem::Version.new("4.0")
+      include ActiveModel::ForbiddenAttributesProtection
+    end
+
     def self.included(base)
       base.extend ClassMethods # ::model_name
     end
@@ -30,6 +34,9 @@ module Reform::Form::ActiveModel
         rename_nested_param_for!(params, dfn)
       end
 
+      if respond_to?(:sanitize_for_mass_assignment, true)
+        params = sanitize_for_mass_assignment(params)
+      end
       super(params)
     end
 

--- a/reform-rails.gemspec
+++ b/reform-rails.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "reform", ">= 2.3.0.rc1", "< 3.0.0"
   spec.add_dependency "activemodel", ">= 3.2"
+  spec.add_development_dependency "actionpack",  ">= 3.2"
 end

--- a/test/activemodel_validation_test.rb
+++ b/test/activemodel_validation_test.rb
@@ -289,32 +289,32 @@ class ActiveModelValidationTest < MiniTest::Spec
   end
 
   describe "validates_each" do
-   class ValidateEachForm < Reform::Form
-     include Reform::Form::ActiveModel::Validations
+    class ValidateEachForm < Reform::Form
+      include Reform::Form::ActiveModel::Validations
 
-     property :songs
+      property :songs
 
-     validation do
-       validates_each :songs do |record, attr, value|
-         record.errors.add attr, "is invalid" unless ['red','green','blue'].include?(value)
-       end
-     end
-   end
+      validation do
+        validates_each :songs do |record, attr, value|
+          record.errors.add attr, "is invalid" unless ['red','green','blue'].include?(value)
+        end
+      end
+    end
 
-   class ValidateEachForm2 < Reform::Form
-     include Reform::Form::ActiveModel::Validations
+    class ValidateEachForm2 < Reform::Form
+      include Reform::Form::ActiveModel::Validations
 
-     property :songs
+      property :songs
 
-     validates_each :songs do |record, attr, value|
-       record.errors.add attr, "is invalid" unless ['red','green','blue'].include?(value)
-     end
-   end
+      validates_each :songs do |record, attr, value|
+        record.errors.add attr, "is invalid" unless ['red','green','blue'].include?(value)
+      end
+    end
 
-   it { ValidateEachForm.new(Album.new).validate(songs: "orange").must_equal false }
-   it { ValidateEachForm.new(Album.new).validate(songs: "red").must_equal true }
+    it { ValidateEachForm.new(Album.new).validate(songs: "orange").must_equal false }
+    it { ValidateEachForm.new(Album.new).validate(songs: "red").must_equal true }
 
-   it { ValidateEachForm2.new(Album.new).validate(songs: "orange").must_equal false }
-   it { ValidateEachForm2.new(Album.new).validate(songs: "red").must_equal true }
- end
+    it { ValidateEachForm2.new(Album.new).validate(songs: "orange").must_equal false }
+    it { ValidateEachForm2.new(Album.new).validate(songs: "red").must_equal true }
+  end
 end

--- a/test/strong_parameters_test.rb
+++ b/test/strong_parameters_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+
+if defined?(ActiveModel::ForbiddenAttributesProtection)
+  # *actionpack* is not a hard gem dependency (just a development dependency); it's just a
+  # convenient reference implementation and the one most Rails users will probably be using. But we
+  # could have used a custom ProtectedParams or whatever like they did in:
+  # - https://github.com/rails/rails/blob/master/activemodel/test/cases/forbidden_attributes_protection_test.rb
+  # - https://github.com/rails/rails/blob/master/activerecord/test/cases/forbidden_attributes_protection_test.rb
+  require "action_controller/metal/strong_parameters"
+
+  class StrongParametersTest < Minitest::Spec
+    if ActiveRecord.gem_version >= Gem::Version.new("5.0")
+      class User
+        include ActiveModel::Model
+        attr_accessor :name
+        attr_accessor :is_superuser
+      end
+    else
+      class User < ActiveRecord::Base
+      end
+    end
+    class UserForm < Reform::Form
+      property :name
+      property :is_superuser
+    end
+
+    describe "when params is an object that responds to `permitted?`" do
+      let(:record) { User.new }
+      let(:form)   { UserForm.new(record) }
+
+      describe "when all params are permitted (safe)" do
+        let(:params) { ActionController::Parameters.new({"name"=>""}).permit(:name) }
+
+        it { assert params.permitted? }
+        it 'ActiveModel and Reform' do
+          # No errors
+          record.assign_attributes(params)
+          form.validate           (params)
+        end
+      end
+
+      describe "when params are not permitted yet (unsafe)" do
+        let(:params) { ActionController::Parameters.new({name: 'name', is_superuser: true}) }
+
+        it { refute params.permitted? }
+        it 'ActiveModel' do
+          assert_raises ActiveModel::ForbiddenAttributesError do
+            record.assign_attributes(params)
+            assert record.is_superuser
+          end
+        end
+        it 'Reform' do
+          assert_raises ActiveModel::ForbiddenAttributesError do
+            form.validate(params)
+          end
+          # *Without* sanitize_for_mass_assignment, this would set is_superuser
+          form.sync
+          assert_nil record.is_superuser
+        end
+      end
+
+      describe "when some params are permitted and others are not (safe)" do
+        let(:params) { ActionController::Parameters.new({name: 'name', is_superuser: true}).permit(:name) }
+
+        it { assert params.permitted? }
+        # No trace of the unpermitted params remains (safe)
+        it { params.                     to_h.must_equal({"name"=>"name"}) }
+        it { params.enum_for(:each_pair).to_h.must_equal({"name"=>"name"}) }
+        it 'ActiveModel' do
+          record.assign_attributes(params)
+          record.name.must_equal 'name'
+          assert_nil record.is_superuser
+        end
+        it 'Reform' do
+          form.validate(params)
+          form.sync
+          record.name.must_equal 'name'
+          assert_nil record.is_superuser
+        end
+      end
+
+      describe "when StrongParameters is 'turned off' (all parameters permitted by top-level default) (unsafe)" do
+        before { ActionController::Parameters.permit_all_parameters = true }
+        after  { ActionController::Parameters.permit_all_parameters = false }
+        let(:params) { ActionController::Parameters.new({name: 'name', is_superuser: true}) }
+
+        it { assert params.permitted? }
+        it { params.                     to_h.must_equal({"name"=>"name", "is_superuser"=>true}) }
+        it { params.enum_for(:each_pair).to_h.must_equal({"name"=>"name", "is_superuser"=>true}) }
+        it 'ActiveModel' do
+          record.assign_attributes(params)
+          assert record.is_superuser
+        end
+        it 'Reform' do
+          form.validate(params)
+          form.sync
+          assert record.is_superuser
+        end
+      end
+    end
+  end
+end

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -19,4 +19,9 @@ ActiveRecord::Schema.define(version: 1) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "users" do |t|
+    t.string   "name"
+    t.boolean  "is_superuser"
+  end
 end


### PR DESCRIPTION
I was recently updating an app to Rails 5 and StrongParameters and was surprised that the controllers only complained when assigning params directly to a model record but *not* when assigning to a form object. This is surprising behavior and seems like a security hole.

If I'm using reform-rails and subclassing `Reform::Form::ActiveModel` (where `ActiveModel` is in the name), I would expect to have it use `ForbiddenAttributesProtection` and raise an error if I pass in an unpermitted `ActionController::Parameters` (or unpermitted _anything_ that responds to `permitted?`), just like `ActiveModel` itself does.

For comparison, see how ActiveModel does it here:
- https://github.com/rails/rails/blob/master/activemodel/lib/active_model/attribute_assignment.rb
- https://github.com/rails/rails/blob/master/activemodel/test/cases/forbidden_attributes_protection_test.rb
- https://github.com/rails/rails/blob/master/activemodel/lib/active_model/forbidden_attributes_protection.rb
- https://github.com/rails/rails/blob/master/activerecord/test/cases/forbidden_attributes_protection_test.rb

This PR adds that behavior to Reform. I tried to match that behavior as closely as I could. And the behavior is still exactly the same as it was before if you pass in a Hash (and you can always pass in `params.to_unsafe_h` if you *really* don't want this safety mechanism).