### PR TITLE
Add custom error messages support to unique validator

### DIFF
--- a/lib/reform/form/validation/unique_validator.rb
+++ b/lib/reform/form/validation/unique_validator.rb
@@ -57,7 +57,7 @@ class Reform::Form::UniqueValidator < ActiveModel::EachValidator
       query = query.where(field => form.send(field))
     end
 
-    form.errors.add(attribute, :taken) if query.count > 0
+    form.errors.add(attribute, options[:message] || :taken) if query.count > 0
   end
 end
 


### PR DESCRIPTION
Add support for custom error messages for using in form objects.
In the current gem state, key `message` in options is ignored:
```
property :email
validates :email, unique: { message: "Custom error message" }
```
