### PR TITLE
Fix erros.add functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@
 /tmp/
 *.gem
 *.sqlite3
-
+.byebug*
 *.log

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ source "https://rubygems.org"
 gemspec
 
 gem 'pry-byebug'
+gem "minitest-line"
 
 case ENV["GEMS_SOURCE"]
   when "local"

--- a/lib/reform/form/active_model/validations.rb
+++ b/lib/reform/form/active_model/validations.rb
@@ -129,6 +129,16 @@ module Reform
             messages.to_s
           end
 
+          def add(key, error_text)
+            # use rails magic to get the correct error_text and make sure we still update details and fields
+            text = @amv_errors.add(key, error_text)
+
+            # but since messages method is actually already defined in `Reform::Contract::Result::Errors
+            # we need to update the @dotted_errors instance variable to add or merge a new error
+            @dotted_errors.key?(key) ? @dotted_errors[key] |= text : @dotted_errors[key] = text
+            instance_variable_set(:@dotted_errors, @dotted_errors)
+          end
+
           def method_missing(m, *args, &block)
             @amv_errors.send(m, *args, &block) # send all methods to the AMV errors, even privates.
           end

--- a/test/activemodel_validation_test.rb
+++ b/test/activemodel_validation_test.rb
@@ -269,8 +269,21 @@ class ActiveModelValidationTest < MiniTest::Spec
       end
       form.errors.empty?.must_equal true
     end
-  end
 
+    it 'able to add errors' do
+      form.validate(username: "yo", email: nil).must_equal false
+      form.errors.messages.must_equal(email: ["can't be blank", "fill it out!"], username: ["not ok", "must be yo"])
+      # add a new custom error
+      form.errors.add(:policy, "error_text")
+      form.errors.messages.must_equal(email: ["can't be blank", "fill it out!"], username: ["not ok", "must be yo"], policy: ["error_text"])
+      # does not duplicate errors
+      form.errors.add(:email, "fill it out!")
+      form.errors.messages.must_equal(email: ["can't be blank", "fill it out!"], username: ["not ok", "must be yo"], policy: ["error_text"])
+      # merge existing errors
+      form.errors.add(:policy, "another error")
+      form.errors.messages.must_equal(email: ["can't be blank", "fill it out!"], username: ["not ok", "must be yo"], policy: ["error_text", "another error"])
+    end
+  end
 
   describe "validates: :acceptance" do
     class AcceptanceForm < Reform::Form


### PR DESCRIPTION
The problem was that we were actually adding the error correctly in the `ActiveModel::Errors` object but the `messages` method was not going through the `ActiveModel::Errors` so we need to update `@dotted_erros` as well.
Overriding the method `messages` to have the messages directly from `ActiveModel::Errors` was breaking a lot of tests (which I think can be a bit alarming in terms of Rails compatibility)  