### PR TITLE
`[]` in errors supports symbol and string lookup

### DIFF
--- a/lib/reform/form/active_model/validations.rb
+++ b/lib/reform/form/active_model/validations.rb
@@ -133,7 +133,7 @@ module Reform
           end
 
           def [](k)
-            super || []
+            super(k.to_sym) || []
           end
 
           # rails expects this to return a stringified hash of the messages

--- a/test/activemodel_validation_test.rb
+++ b/test/activemodel_validation_test.rb
@@ -44,6 +44,8 @@ class ActiveModelValidationTest < MiniTest::Spec
   it do
     form.validate({}).must_equal false
     form.errors.messages.inspect.must_equal "{:username=>[\"can't be blank\"], :email=>[\"can't be blank\"]}"
+    form.errors[:username].must_equal ["can't be blank"]
+    form.errors['username'].must_equal ["can't be blank"]
   end
 
   # partially invalid.


### PR DESCRIPTION
ActionView looks for errors messages using string names, which is breaking error message display in Rails 5.1. The ActiveModel error object converts to symbols in it's `[]` method:

For example:

```
[140, 149] in activemodel-5.1.7/lib/active_model/errors.rb
   140:     #
   141:     #   person.errors.keys    # => []
   142:     #   person.errors[:name]  # => []
   143:     #   person.errors.keys    # => [:name]
   144:     def [](attribute)
=> 145:       messages[attribute.to_sym]
   146:     end
```

This copies the implementation into reform's error object and allows
looking for error messages via strings and symbols.

Note: Travis CI tests are still failing since reform 2.3.0rc2 has not been released (see https://github.com/trailblazer/reform-rails/pull/76)