### PR TITLE
Implement respond_to that delegates to AMV errors

### DIFF
--- a/lib/reform/form/active_model/validations.rb
+++ b/lib/reform/form/active_model/validations.rb
@@ -160,6 +160,10 @@ module Reform
           def method_missing(m, *args, &block)
             @amv_errors.send(m, *args, &block) # send all methods to the AMV errors, even privates.
           end
+
+          def respond_to?(method)
+            @amv_errors.respond_to?(method) ? true : super
+          end
         end
       end
 


### PR DESCRIPTION
Reform-rails is delegating missing methods to the AMV errors object, but
there isn't a matching `respond_to?` method that is delegating in the
same way.

Other gems (such as shoulda_matchers) call `respond_to?` before invoking
a method, which means these gems do not end up believing they are
working with an AMV compatible errors object (but they are).

Adding this `respond_to?` implementation fixes this issue.