### PR TITLE
Override reform full_messages to use ActiveModel full_messages

### DIFF
--- a/lib/reform/form/active_model/validations.rb
+++ b/lib/reform/form/active_model/validations.rb
@@ -164,6 +164,10 @@ module Reform
           def respond_to?(method)
             @amv_errors.respond_to?(method) ? true : super
           end
+
+          def full_messages
+            @amv_errors.full_messages
+          end
         end
       end
 

--- a/lib/reform/form/active_model/validations.rb
+++ b/lib/reform/form/active_model/validations.rb
@@ -166,7 +166,23 @@ module Reform
           end
 
           def full_messages
-            @amv_errors.full_messages
+            base_errors = @amv_errors.full_messages
+            form_fields = @amv_errors.instance_variable_get(:@base).instance_variable_get(:@fields)
+            nested_errors = full_messages_for_nested_fields(form_fields)
+            
+            [base_errors, nested_errors].flatten.compact
+          end
+          
+          def full_messages_for_nested_fields(form_fields)
+            form_fields.map do |field|
+              field_value = field[1]
+              field_is_a_collection = field_value.class == Disposable::Twin::Collection
+              return field_value.map { |twin_collection| collection_full_messages(twin_collection) } if field_is_a_collection
+            end
+          end
+
+          def collection_full_messages(twin_collection)
+            twin_collection.instance_variable_get(:@amv_errors).full_messages
           end
         end
       end

--- a/lib/reform/form/active_model/validations.rb
+++ b/lib/reform/form/active_model/validations.rb
@@ -172,17 +172,26 @@ module Reform
             
             [base_errors, nested_errors].flatten.compact
           end
+
+          private
           
           def full_messages_for_nested_fields(form_fields)
-            form_fields.map do |field|
-              field_value = field[1]
-              field_is_a_collection = field_value.class == Disposable::Twin::Collection
-              return field_value.map { |twin_collection| collection_full_messages(twin_collection) } if field_is_a_collection
-            end
+            form_fields.map { |field| full_messages_for_twin(field[1]) }
           end
 
-          def collection_full_messages(twin_collection)
-            twin_collection.instance_variable_get(:@amv_errors).full_messages
+          def full_messages_for_twin(object)
+            return get_collection_errors(object) if object.is_a? Disposable::Twin::Collection
+            return get_amv_errors(object) if object.is_a? Disposable::Twin
+
+            nil
+          end
+
+          def get_collection_errors(twin_collection)
+            twin_collection.map { |twin| get_amv_errors(twin) }
+          end
+
+          def get_amv_errors(object)
+            object.instance_variable_get(:@amv_errors).full_messages
           end
         end
       end

--- a/test/active_model_custom_validation_translations_test.rb
+++ b/test/active_model_custom_validation_translations_test.rb
@@ -72,4 +72,12 @@ class ActiveModelCustomValidationTranslationsTest < MiniTest::Spec
       _(form.errors[:title]).must_include "Custom Error Message"
     end
   end
+
+  describe 'when calling full_messages' do
+    it 'translates the field name' do
+      form = SongForm::WithBlock.new(Song.new)
+      form.validate({})
+      _(form.errors.full_messages).must_include "Song Title can't be blank"
+    end
+  end
 end

--- a/test/active_model_custom_validation_translations_test.rb
+++ b/test/active_model_custom_validation_translations_test.rb
@@ -40,6 +40,14 @@ class ActiveModelCustomValidationTranslationsTest < MiniTest::Spec
       errors.add :title, :too_short, count: 15
     end
 
+    property :artist, :populate_if_empty => Artist do
+      property :name
+
+      validate do
+        errors.add :name, :blank
+      end
+    end
+
     collection :songs, :populate_if_empty => Song do
       property :title
 
@@ -99,11 +107,11 @@ class ActiveModelCustomValidationTranslationsTest < MiniTest::Spec
     describe 'when using nested_model_attributes' do
       it 'translates the nested model attributes name' do
         album = Album.create(title: 'Greatest Hits')
-        form = AlbumForm.new(album)
-        form.songs << Song.create(title: 'Your favorite song')
+        form = AlbumForm.new(album, artist: Artist.new, songs: [Song.new])
         form.validate({})        
         _(form.errors.full_messages).must_include "Custom Album Title is too short (minimum is 15 characters)"
         _(form.errors.full_messages).must_include "Custom Song Title can't be blank"
+        _(form.errors.full_messages).must_include "Custom Artist Name can't be blank"
       end
     end
   end

--- a/test/fixtures/locales/en.yml
+++ b/test/fixtures/locales/en.yml
@@ -8,6 +8,8 @@ en:
         title: Custom Song Title
       album:
         title: Custom Album Title
+      artist:
+        name: Custom Artist Name
     errors:
       models:
         song:

--- a/test/fixtures/locales/en.yml
+++ b/test/fixtures/locales/en.yml
@@ -5,7 +5,9 @@ en:
   activemodel:
     attributes:
       song:
-        title: "Song Title"
+        title: Custom Song Title
+      album:
+        title: Custom Album Title
     errors:
       models:
         song:
@@ -40,3 +42,7 @@ en:
               attributes:
                 name:
                   taken: has already been taken
+        active_model_custom_validation_translations_test/album:
+              attributes:
+                title:
+                  too_short: is too short

--- a/test/fixtures/locales/en.yml
+++ b/test/fixtures/locales/en.yml
@@ -3,6 +3,9 @@ en:
   # custom validation error messages
 
   activemodel:
+    attributes:
+      song:
+        title: "Song Title"
     errors:
       models:
         song:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,10 @@ module Dummy
   class Application < Rails::Application
     config.eager_load = false
     config.active_support.deprecation = :stderr
+    
+    if config.respond_to?(:active_model)
+      config.active_model.i18n_customize_full_message = true
+    end      
   end
 end
 


### PR DESCRIPTION
Reform has its own full_messages implementation as we can see here
https://github.com/trailblazer/reform/blob/master/lib/reform/errors.rb#L29
and reform-rails ResultErrors class inherits from
Reform::Contract::Result::Errors, so when you call "full_messages" to
get the full error messages, it was calling reform full_messages
implementation instead of delegating to ActiveModel and this is a
problem for whom need to translate attribute names, because reform only
humanizes the attribute name.

I've do some "hacks" to get the full error messages of collections/nested properties of the form, if there is another better way to get the full_messages from AM, I'm open to the possibilities.

Fixes: #56 
Fixes: #83

If I'm missing anything, please let me know.