### PR TITLE
Forward error options when calling `form.errors.add()`

### DIFF
--- a/lib/reform/form/active_model/validations.rb
+++ b/lib/reform/form/active_model/validations.rb
@@ -141,9 +141,9 @@ module Reform
             messages.to_s
           end
 
-          def add(key, error_text)
+          def add(key, error_text, **error_options)
             # use rails magic to get the correct error_text and make sure we still update details and fields
-            error = @amv_errors.add(key, error_text)
+            error = @amv_errors.add(key, error_text, **error_options)
             error = [error.message] unless error.is_a?(Array)
 
             # using error_text instead of text to either keep the symbol which will be
@@ -171,12 +171,12 @@ module Reform
             base_errors = @amv_errors.full_messages
             form_fields = @amv_errors.instance_variable_get(:@base).instance_variable_get(:@fields)
             nested_errors = full_messages_for_nested_fields(form_fields)
-            
+
             [base_errors, nested_errors].flatten.compact
           end
 
           private
-          
+
           def full_messages_for_nested_fields(form_fields)
             form_fields.map { |field| full_messages_for_twin(field[1]) }
           end

--- a/test/activemodel_validation_test.rb
+++ b/test/activemodel_validation_test.rb
@@ -326,6 +326,9 @@ class ActiveModelValidationTest < MiniTest::Spec
       _(form.errors.details).must_equal(
         policy: [{error: "error_text"}, {error: "another error"}]
       )
+
+      form.errors.add(:email, :less_than_or_equal_to, count: 2)
+      _(form.errors.messages[:email]).must_equal(["must be less than or equal to 2"])
     end
   end
 


### PR DESCRIPTION
ActiveModel accepts error options which might be used for error message interpolation for example.