### PR TITLE
`:conditions` option is added to unique validator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# x.x.x
+
+* add `conditions` option to Reform Uniqueness validation.
+
 # 0.2.6
 
 * Allow to override `#persisted?` and friends with modules.

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -6,6 +6,7 @@ ActiveRecord::Schema.define(version: 1) do
     t.integer  "album_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "archived_at"
   end
 
   create_table "artists" do |t|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,10 +11,10 @@ module Dummy
   class Application < Rails::Application
     config.eager_load = false
     config.active_support.deprecation = :stderr
-    
+
     if config.respond_to?(:active_model)
       config.active_model.i18n_customize_full_message = true
-    end      
+    end
   end
 end
 


### PR DESCRIPTION
When validating uniqueness sometimes we need to create a condition in the SQL query to scope the uniqueness to partial set, no the whole table. This is also needed if you create unique partial indexes.