### PR TITLE
ActiveModel Acceptance Validator is patched after active model is loaded

### DIFF
--- a/lib/reform/form/active_model/acceptance_validator_patch.rb
+++ b/lib/reform/form/active_model/acceptance_validator_patch.rb
@@ -1,0 +1,36 @@
+module Reform::Form::ActiveModel
+  module AcceptanceValidatorPatch
+    def self.apply!
+      return if defined?(::ActiveModel::Validations::ReformAcceptanceValidator)
+
+      klass = Class.new(::ActiveModel::EachValidator) do
+        def initialize(options)
+          super({ allow_nil: true, accept: ["1", true] }.merge!(options))
+        end
+
+        def validate_each(record, attribute, value)
+          unless acceptable_option?(value)
+            if Gem::Version.new(::ActiveModel::VERSION::STRING) >= Gem::Version.new('6.1.0')
+              record.errors.add(attribute, :accepted, **options.except(:accept, :allow_nil))
+            else
+              record.errors.add(attribute, :accepted, options.except(:accept, :allow_nil))
+            end
+          end
+        end
+
+        private
+
+        def acceptable_option?(value)
+          Array(options[:accept]).include?(value)
+        end
+      end
+
+      # Assign the class to a constant for tracking
+      ::ActiveModel::Validations.const_set(:ReformAcceptanceValidator, klass)
+
+      # Override the built-in validator
+      ::ActiveModel::Validations.send(:remove_const, :AcceptanceValidator)
+      ::ActiveModel::Validations.const_set(:AcceptanceValidator, klass)
+    end
+  end
+end

--- a/lib/reform/rails.rb
+++ b/lib/reform/rails.rb
@@ -4,29 +4,3 @@ require "reform/rails/railtie"
 
 module Reform
 end
-
-module ActiveModel
-  module Validations
-    class AcceptanceValidator < EachValidator # :nodoc:
-      def initialize(options)
-        super({ allow_nil: true, accept: ["1", true] }.merge!(options))
-      end
-
-      def validate_each(record, attribute, value)
-        unless acceptable_option?(value)
-          if Gem::Version.new(ActiveModel::VERSION::STRING) >= Gem::Version.new('6.1.0')
-            record.errors.add(attribute, :accepted, **options.except(:accept, :allow_nil))
-          else
-            record.errors.add(attribute, :accepted, options.except(:accept, :allow_nil))
-          end
-        end
-      end
-
-      private
-
-        def acceptable_option?(value)
-          Array(options[:accept]).include?(value)
-        end
-    end
-  end
-end

--- a/lib/reform/rails/railtie.rb
+++ b/lib/reform/rails/railtie.rb
@@ -57,6 +57,17 @@ module Reform
           include Reform::Form::Dry
         end
       end
+
+      initializer "reform.patch_acceptance_validator" do
+        require "reform/form/active_model/acceptance_validator_patch"
+
+        if defined?(::ActiveModel::Validations::AcceptanceValidator)
+          Reform::Form::ActiveModel::AcceptanceValidatorPatch.apply!
+        else
+          ActiveSupport.on_load(:active_record) { Reform::Form::ActiveModel::AcceptanceValidatorPatch.apply! }
+          Rails.application.config.to_prepare { Reform::Form::ActiveModel::AcceptanceValidatorPatch.apply! }
+        end
+      end
     end # Railtie
   end
 end


### PR DESCRIPTION
Acceptance Validator hasn't been working in Reform the whole time, so I've decided to monkey patch and keep the validator simple to make it work with Reform.